### PR TITLE
fix: add gcloud homebrew installation path

### DIFF
--- a/plugins/gcloud/gcloud.plugin.zsh
+++ b/plugins/gcloud/gcloud.plugin.zsh
@@ -9,6 +9,7 @@ if [[ -z "${CLOUDSDK_HOME}" ]]; then
     "/usr/local/share/google-cloud-sdk"
     "/usr/local/Caskroom/google-cloud-sdk/latest/google-cloud-sdk"
     "/opt/homebrew/Caskroom/google-cloud-sdk/latest/google-cloud-sdk"
+    "/opt/homebrew/share/google-cloud-sdk"
     "/usr/share/google-cloud-sdk"
     "/snap/google-cloud-sdk/current"
     "/snap/google-cloud-cli/current"


### PR DESCRIPTION
## Standards checklist:

<!-- Fill with an x the ones that apply. Example: [x] -->

- [x] The PR title is descriptive.
- [x] The PR doesn't replicate another PR which is already open.
- [x] I have read the contribution guide and followed all the instructions.
- [x] The code follows the code style guide detailed in the wiki.
- [x] The code is mine or it's from somewhere with an MIT-compatible license.
- [x] The code is efficient, to the best of my ability, and does not waste computer resources.
- [x] The code is stable and I have tested it myself, to the best of my abilities.
- [x] If the code introduces new aliases, I provide a valid use case for all plugin users down below.

## Changes:

- Add `/opt/homebrew/share` to glcoud installation search paths

## Other comments:
I don't know enough about to internals of homebrew to understand why this path is different than existing options. But I have new mac and just installed google-cloud-sdk:
```
==> Caveats
  for zsh users
    source "$(brew --prefix)/share/google-cloud-sdk/path.zsh.inc"
    source "$(brew --prefix)/share/google-cloud-sdk/completion.zsh.inc"

➜  brew --prefix
/opt/homebrew
```
